### PR TITLE
feat(noProperTimeHandling): handle no time set

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,21 +24,26 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
             <!-- Make this the first activity that is displayed when the device boots. -->
-            <!--            <intent-filter>
-                            <action android:name="android.intent.action.MAIN"/>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
-                            <category android:name="android.intent.category.HOME"/>
-                            <category android:name="android.intent.category.DEFAULT"/>
-                        </intent-filter>
-            -->
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".AutoTimerActivity"
-            android:theme="@android:style/Theme.DeviceDefault.Light.NoActionBar.Fullscreen">
-        </activity>
-        <activity android:name=".RoomChoiceActivity"
-            android:theme="@android:style/Theme.DeviceDefault.Light.NoActionBar.Fullscreen">
-        </activity>
+            android:theme="@android:style/Theme.DeviceDefault.Light.NoActionBar.Fullscreen"></activity>
+        <activity
+            android:name=".RoomChoiceActivity"
+            android:theme="@android:style/Theme.DeviceDefault.Light.NoActionBar.Fullscreen"></activity>
+
+        <receiver android:name=".TimeChangeBroadcastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/tech/touraine/timer/MainActivity.kt
+++ b/app/src/main/java/tech/touraine/timer/MainActivity.kt
@@ -5,15 +5,15 @@ import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.os.CountDownTimer
-import android.util.Log
+import android.provider.Settings
 import android.view.KeyEvent
-import android.widget.TextView
-import android.widget.Button
-import android.view.animation.Animation
 import android.view.animation.AlphaAnimation
-import java.io.Closeable
+import android.view.animation.Animation
+import android.widget.Button
+import android.widget.TextView
+import android.widget.Toast
 import com.google.android.things.device.TimeManager
-import java.io.Console
+import java.io.Closeable
 import java.util.*
 
 
@@ -59,6 +59,12 @@ class MainActivity : Activity() {
         val timeManager = TimeManager.getInstance()
         timeManager.setTimeFormat(TimeManager.FORMAT_24)
         timeManager.setTimeZone("Europe/Paris")
+
+        //arbitrary timestamp 2019/12/30
+        if (Date().toInstant().epochSecond < 1_577_695_721L){
+            //redirect to set wifi screen to get a time, once set the app will auto resume
+            startActivity(Intent(Settings.ACTION_WIFI_SETTINGS));
+        }
 
         buttons = Buttons()
         buzzer = Buzzer()

--- a/app/src/main/java/tech/touraine/timer/TimeChangeBroadcastReceiver.kt
+++ b/app/src/main/java/tech/touraine/timer/TimeChangeBroadcastReceiver.kt
@@ -1,0 +1,21 @@
+package tech.touraine.timer
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class TimeChangeBroadcastReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.getAction();
+
+        if (action == Intent.ACTION_TIME_CHANGED ||
+                action == Intent.ACTION_TIMEZONE_CHANGED) {
+            val restartIntent = Intent(context, MainActivity::class.java).apply{
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                setAction(Intent.ACTION_MAIN)
+                addCategory(Intent.CATEGORY_LAUNCHER)
+            }
+            context.startActivity(restartIntent)
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 09 22:04:13 CET 2019
+#Mon Dec 30 09:28:52 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
When booting device at conference location, there is no network available, thus no time set.

If this happens, redirect to system settings to allow the user to set up wifi, the app resumes automagically then.